### PR TITLE
Use ontology URI derivative for namespace

### DIFF
--- a/docs/current/po.ttl
+++ b/docs/current/po.ttl
@@ -1,4 +1,4 @@
-@prefix : <http://www.essepuntato.it/2008/12/pattern#> .
+@prefix : <http://purl.org/spar/po/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix owl2xml: <http://www.w3.org/2006/12/owl2-xml#> .


### PR DESCRIPTION
All other SPAR ontologies use a form of the namespace http://purl.org/spar for their namespace except this one. It uses http://purl.org/spar/po for the ontology URI but the namespace is the older essepuntato one. This just needs to be updated, as per this single-line update.